### PR TITLE
(fix): Fixed missing content change and banner + layout displays

### DIFF
--- a/src/components/app/misc/banner.tsx
+++ b/src/components/app/misc/banner.tsx
@@ -4,7 +4,7 @@ type BannerProps = {
 
 export function Banner({ children }: BannerProps) {
   return (
-    <div className="container mx-auto flex h-64 shrink-0 flex-col items-center-safe justify-center-safe gap-8 bg-gradient-to-br from-green-500 to-teal-500 p-4 text-center text-white lg:bg-transparent lg:bg-none">
+    <div className="container mx-auto flex h-64 shrink-0 flex-col items-center-safe justify-center-safe gap-8 bg-gradient-to-br from-green-500 to-teal-500 p-4 text-center text-white sm:bg-transparent sm:bg-none">
       {children}
     </div>
   )

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -86,7 +86,7 @@ export function Layout({
         </header>
 
         {banner}
-        <div className="container mx-auto flex grow flex-col justify-around gap-16 bg-gray-50 py-16 xl:rounded-t-lg">
+        <div className="container mx-auto flex grow flex-col justify-around gap-16 bg-gray-50 py-16 sm:rounded-t-lg">
           {children}
         </div>
 

--- a/src/data/about.yaml
+++ b/src/data/about.yaml
@@ -19,4 +19,4 @@
       message: 'Cutting-edge platform tailored to modern business needs.'
 
     - caption: 'Customer Focus'
-      message: ''
+      message: 'Commitment to exceptional service and support.'


### PR DESCRIPTION
On the about page there was missing message after Customer focus.
In general, there were some issues with how smaller screens displayed the banner and the main content which are now fixed.